### PR TITLE
Add hero introduction section with safe-area layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,9 @@
 
     <main id="content" aria-labelledby="content-title">
       <h1 id="content-title" class="visually-hidden">CLASSNOE MESTO inspired narrative</h1>
+      <section class="hero-intro" aria-label="Intro">
+        <h1 class="hero-title">CLASSNOE MESTO</h1>
+      </section>
       <section id="sentences" role="list" aria-live="polite"></section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -282,6 +282,16 @@ if (document.readyState === 'loading') {
   initSentences();
 }
 
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.querySelector('[data-scroll-to-sentences]');
+  const target = document.getElementById('sentences');
+  if (btn && target) {
+    btn.addEventListener('click', () => {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+});
+
 (function () {
   const toggle = document.querySelector('[data-menu-toggle]');
   const menu = document.getElementById('site-menu');

--- a/styles.css
+++ b/styles.css
@@ -322,6 +322,33 @@ main {
   min-height: 100vh;
 }
 
+.hero-intro {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 100vh;
+  min-height: 100svh;
+  min-height: 100dvh;
+  padding:
+    calc(16px + var(--safe-top))
+    calc(16px + var(--safe-right))
+    calc(16px + var(--safe-bottom))
+    calc(16px + var(--safe-left));
+  background: transparent;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-title {
+  margin: 0;
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: 0.02em;
+  font-size: clamp(32px, 8vw, 64px);
+  color: #fff;
+}
+
 .site-header {
   position: sticky;
   top: 0;
@@ -525,6 +552,7 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   max-height: none;
   overflow: visible;
   perspective: 1400px;
+  scroll-margin-top: 72px;
 }
 
 #sentences .sentence {


### PR DESCRIPTION
## Summary
- add a hero intro section ahead of the sentence list to present the CLASSNOE MESTO title on first view
- style the hero to center its content while respecting safe-area insets and keep sentences offset for sticky header
- enable smooth scrolling to the sentences section when the brand button is used as a trigger

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d82ba255188331879497645f3ceff9