### PR TITLE
Tweak header branding visibility and safe-area spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,7 @@
         </div>
       </div>
     </footer>
+    <div class="footer-spacer" aria-hidden="true"></div>
   </div>
   <pre
     id="safe-debug"

--- a/script.js
+++ b/script.js
@@ -593,3 +593,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   trigger.addEventListener('click', scrollToSentences);
 })();
+
+document.addEventListener('DOMContentLoaded', () => {
+  const hero = document.querySelector('.hero-intro');
+  if (!hero) return;
+
+  const ro = new IntersectionObserver(([e]) => {
+    document.body.classList.toggle('is-past-hero', e.intersectionRatio === 0);
+  }, { threshold: 0, rootMargin: '0px 0px 0px 0px' });
+
+  ro.observe(hero);
+});

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,11 @@ body {
   clip-path: none !important;
 }
 
+/* Гарантированный нижний отступ для обычного контента */
+body {
+  padding-bottom: calc(16px + var(--safe-bottom));
+}
+
 body.has-menu-open,
 body.is-menu-closing {
   overflow: hidden;
@@ -552,7 +557,8 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   max-height: none;
   overflow: visible;
   perspective: 1400px;
-  scroll-margin-top: 72px;
+  scroll-margin-top: calc(var(--safe-top) + 56px);
+  padding-bottom: calc(24px + var(--safe-bottom));
 }
 
 #sentences .sentence {
@@ -684,6 +690,7 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
 
   #sentences {
     padding: clamp(48px, 16vh, 120px) clamp(20px, 9vw, 52px) clamp(200px, 56vh, 360px);
+    padding-bottom: calc(24px + var(--safe-bottom));
   }
 
   .sentence {
@@ -707,6 +714,23 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   .site-menu__list {
     gap: clamp(20px, 8vw, 48px);
   }
+}
+
+/* 1) Сначала полностью скрываем текст бренда в шапке (ай-аксессибл оставляем) */
+.site-brand {
+  font-size: 0;
+  line-height: 0;
+}
+
+/* 2) Когда прокрутили герой — показываем компактную версию бренда в шапке */
+body.is-past-hero .site-brand {
+  font-size: 18px;
+  line-height: 1.2;
+  letter-spacing: 0.02em;
+}
+
+.footer-spacer {
+  height: calc(16px + var(--safe-bottom));
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary
- hide the header brand text on the hero screen and reveal a compact version after scrolling past the hero
- add an IntersectionObserver to toggle the compact branding state once the hero leaves the viewport
- extend bottom safe-area padding, protect the sentences section, and add a footer spacer to avoid home-indicator overlap

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82e344d808331ba512c234d0028c7